### PR TITLE
java.lang.NullPointerException in classes.rb line 13 

### DIFF
--- a/lib/open-nlp/classes.rb
+++ b/lib/open-nlp/classes.rb
@@ -12,10 +12,9 @@ class OpenNLP::POSTaggerME < OpenNLP::Base
     def tag(*args)
         @proxy_inst._invoke("tag", "[Ljava.lang.String;", args[0])
     end
-
   end
-end
 
+end
 
 class OpenNLP::ChunkerME < OpenNLP::Base
 


### PR DESCRIPTION
Revised classes,rb to use RJB _invoke method to make the call directly instead of passing through Utils.class which was causing these errors.  _invoke is used to make the call strongly typed to ensure parameters are passed correctly.
