### PR TITLE
Fix Bundler dependency loop

### DIFF
--- a/lib/open-nlp.rb
+++ b/lib/open-nlp.rb
@@ -1,7 +1,7 @@
 module OpenNLP
 
   # Library version.
-  VERSION = '0.1.4'
+  require 'open-nlp/version'
 
   # Require Java bindings.
   require 'open-nlp/bindings'

--- a/lib/open-nlp/version.rb
+++ b/lib/open-nlp/version.rb
@@ -1,0 +1,3 @@
+module OpenNLP
+  VERSION = '0.1.4'
+end

--- a/open-nlp.gemspec
+++ b/open-nlp.gemspec
@@ -1,6 +1,6 @@
 $:.push File.expand_path('../lib', __FILE__)
 
-require 'open-nlp'
+require 'open-nlp/version'
 
 Gem::Specification.new do |s|
 


### PR DESCRIPTION
Hi,

I was having a problem with `Bundler` resolving dependencies of `open-nlp`, trying to require `bind-it` before it was installed. The solution: do not require the whole `OpenNLP` library in the `.gemspec`, but rather just my newly introduced `open-nlp/version` file.

Thanks,
Amir
